### PR TITLE
Fix REAP MCTS algorithm implementation

### DIFF
--- a/Reap/PremiseSelection/API.lean
+++ b/Reap/PremiseSelection/API.lean
@@ -14,6 +14,8 @@ deriving ToJson, FromJson
 structure PremiseSelectionResult where
   formal_name : String
   formal_statement : String
+  informal_statement : String
+  informal_name : String
 deriving ToJson, FromJson, Repr
 
 structure PremiseSelectionClient where

--- a/Reap/Tactic/Generator.lean
+++ b/Reap/Tactic/Generator.lean
@@ -38,6 +38,15 @@ def stripThinkingPrefix (s : String) : String :=
     else s
   else s
 
+/-- Remove a few common non-tactic prefixes emitted by generic chat models. -/
+def normalizeGeneration (s : String) : String :=
+  let s := stripThinkingPrefix s
+  let s := s.trimAsciiStart.toString
+  if s.startsWith "<;>" then
+    (String.intercalate "<;>" ((s.splitOn "<;>").drop 1)).trimAsciiStart.toString
+  else
+    s
+
 def filterGeneration (s: String) : Bool :=
   let banned := ["sorry", "admit", "▅", "apply?", "exact?", "refine?", "calc?", "hint"]
   !(banned.any fun s' => (s.splitOn s').length > 1)
@@ -57,32 +66,42 @@ def parseCompletionResponseOpenAI (res: OpenAICompletionResponse) : Array String
   (res.choices.map fun x => (x.text)).toArray
 
 def parseChatResponseOpenAI (res: OpenAIChatResponse) : Array (String × Float) :=
-  (res.choices.map fun x => (stripThinkingPrefix x.message.content, x.computeLogProbability)).toArray
+  (res.choices.map fun x => (normalizeGeneration x.message.content, x.computeLogProbability)).toArray
 
-def mkValuePrompt (tacticState : String) : String :=
-  "Please estimate how many tactic steps are required to solve this proof state in Lean.
-STATE:
-" ++ tacticState
+def normalizeCandidatePriors (xs : Array (String × Float)) : Array (String × Float) :=
+  if xs.isEmpty then
+    #[]
+  else
+    let maxLogprob := xs.foldl (init := xs[0]!.2) fun acc (_, logprob) => max acc logprob
+    let weights := xs.map fun (_, logprob) => Float.exp (logprob - maxLogprob)
+    let total := weights.foldl (init := (0.0 : Float)) fun acc weight => acc + weight
+    if total <= (0.0 : Float) then
+      let uniform := 1.0 / xs.size.toFloat
+      xs.map fun (tactic, _) => (tactic, uniform)
+    else
+      (xs.zipIdx.map fun | ((tactic, _), i) => (tactic, weights[i]! / total))
 
-def mkRelatedTheorem (_id: Nat) (ps : PremiseSelectionResult) : String :=
+def mkRelatedTheorem (id: Nat) (ps : PremiseSelectionResult) : String :=
   let formalName := ps.formal_name
-  -- let informalName := ps.informal_name
+  let informalName := ps.informal_name
   let formalStatement := ps.formal_statement
-  -- "ID: " ++ toString id ++ "\n" ++
+  "ID: " ++ toString id ++ "\n" ++
   "Formal name: " ++ formalName ++ "\n" ++
-  -- "Informal name: " ++ informalName ++ "\n" ++
+  "Informal name: " ++ informalName ++ "\n" ++
   "Formal statement: " ++ formalStatement
 
 def mkPrompt (tacticState : String) (relatedTheorems: Array PremiseSelectionResult) : String :=
   "User: Please generate a tactic in lean4 to solve the state.
 Here're some theorems that may be helpful:
-" ++ (Array.mapIdx' mkRelatedTheorem relatedTheorems |>.joinSep "\n") ++
-"
+" ++ (Array.mapIdx' mkRelatedTheorem relatedTheorems |>.joinSep "\n") ++ "
 STATE:
 " ++ tacticState ++ "
 TACTIC:
 
 Assistant:"
+
+def mkValuePrompt (tacticState : String) (relatedTheorems: Array PremiseSelectionResult) : String :=
+  mkPrompt tacticState relatedTheorems
 
 def getClient : CoreM TacticGenerator := do
   return {
@@ -96,10 +115,8 @@ def generatePPTactics (ppGoal : String) : CoreM (Array PremiseSelectionResult ×
   let opts ← getOptions
   withCumulativeWallClockTime "reap.wall.tactic_gen" do
     let generator ← getClient
-    let relatedTheorems ← withCumulativeWallClockTime "reap.wall.premise_select" do
-      pure <|
-        (← retryCoreM?
-          (PremiseSelectionClient.getPremises ppGoal (reap.num_premises.get opts))).getD #[]
+    let relatedTheorems ←
+      PremiseSelectionClient.getPremises ppGoal (reap.num_premises.get opts)
     let prompt := mkPrompt ppGoal relatedTheorems
     -- let mut results : Std.HashSet String := Std.HashSet.emptyWithCapacity
     let mut results : List (String × Float) := []
@@ -116,20 +133,24 @@ def generatePPTactics (ppGoal : String) : CoreM (Array PremiseSelectionResult ×
       results := results.insert result
       -- logInfo m!"Generated tactic: {result.1} with probability {result.2}"
     results := results.eraseDupsBy (fun x y => x.1 == y.1)
-    let finalResults := (results.toArray.filter fun x => filterGeneration x.1)
+    let finalResults :=
+      normalizeCandidatePriors <| (results.toArray.filter fun x => filterGeneration x.1)
     -- let finalResults := (results.toArray.filter filterGeneration).map fun x => (x, 1.0)
     return (relatedTheorems, finalResults)
 
-def Meta.ppProofState (mvarIds : List MVarId) : MetaM Format := do
-  return Std.Format.joinSep (← mvarIds.mapM (Meta.ppGoal)) "\n".toFormat
+def Meta.ppProofState (mvarIds : List MVarId) : MetaM String := do
+  let goals ← mvarIds.mapM fun mvarId => do
+    let ppGoal := toString (← Meta.ppGoal mvarId)
+    return ppGoal
+  return String.intercalate "\n\n" goals
 
 
 def generateTactics (mvarIds : List MVarId) : MetaM <| Array (String × Float) := do
-  let ppProofState := toString (← Meta.ppProofState mvarIds)
+  let ppProofState ← Meta.ppProofState mvarIds
   return (← generatePPTactics ppProofState).2
 
 def generateTacticsWithPremises (mvarIds : List MVarId) : MetaM <| Array (String × Array PremiseSelectionResult × Float) := do
-  let ppProofState := toString (← Meta.ppProofState mvarIds)
+  let ppProofState ← Meta.ppProofState mvarIds
   let (ps, res) ← generatePPTactics ppProofState
   return res.map fun (x, y) => (x, ps, y)
 
@@ -141,8 +162,10 @@ def generateValue (mvarIds : List MVarId) : MetaM Float := do
   let opts ← getOptions
   withCumulativeWallClockTime "reap.wall.value" do
     let generator ← getClient
-    let ppProofState := toString (← Meta.ppProofState mvarIds)
-    let prompt := mkValuePrompt ppProofState
+    let ppProofState ← Meta.ppProofState mvarIds
+    let relatedTheorems ←
+      PremiseSelectionClient.getPremises ppProofState (reap.num_premises.get opts)
+    let prompt := mkValuePrompt ppProofState relatedTheorems
     let req : OpenAIChatRequest := {
       model := reap.model.get opts,
       messages := [ { role := "user", content := prompt } ],
@@ -161,4 +184,4 @@ def generateValue (mvarIds : List MVarId) : MetaM Float := do
         | .error _ => throwError "Failed to decode value response"
       else
         throwError "Failed to parse value response as JSON"
-    return -result.get!.score
+    return result.get!.score

--- a/Reap/Tactic/TreeSearch.lean
+++ b/Reap/Tactic/TreeSearch.lean
@@ -1,5 +1,6 @@
 module
 public meta import Lean
+public meta import Lean.Elab.SyntheticMVars
 public meta import Reap.PremiseSelection.API
 public meta import Reap.Tactic.WallClock
 public meta import TreeSearch.BestFirst
@@ -16,23 +17,36 @@ register_option reap.heartbeats : Nat := {
   descr := "Maximum heartbeats per tactic"
 }
 
-def withHeartbeats {m : Type _ → Type _} {α : Type _} [Monad m] [MonadWithReaderOf Core.Context m] (heartbeats : Nat) : m α → m α :=
-  withReader (fun s => { s with maxHeartbeats := heartbeats })
+def withHeartbeats {α : Type _} (heartbeats : Nat) (x : TacticM α) : TacticM α :=
+  Core.withCurrHeartbeats <| withTheReader Core.Context (fun s => { s with maxHeartbeats := heartbeats }) x
 
 def evalTacticStr (str : String) (heartbeats : Nat) : TacticM (Option Tactic.SavedState) := do
   withCumulativeWallClockTime "reap.wall.tactic_eval" do
     let .ok stx := Parser.runParserCategory (← getEnv) `tactic str | return none
+    let savedState ← Tactic.saveState
+    let savedMessages := (← getThe Core.State).messages
+    modifyThe Core.State fun st => { st with messages := {} }
     try
       let success ← tryCatchRuntimeEx (handler := fun _ => return false) do
-        withHeartbeats heartbeats <| evalTactic stx
+        withHeartbeats heartbeats <| do
+          evalTactic stx
+          Term.synthesizeSyntheticMVarsNoPostponing
+          pruneSolvedGoals
         return true
       if success then
-        pruneSolvedGoals
         if (← getThe Core.State).messages.hasErrors then
+          savedState.restore
+          modifyThe Core.State fun st => { st with messages := savedMessages }
           return none
       else
+        savedState.restore
+        modifyThe Core.State fun st => { st with messages := savedMessages }
         return none
-    catch _ => return none
+    catch _ =>
+      savedState.restore
+      modifyThe Core.State fun st => { st with messages := savedMessages }
+      return none
+    modifyThe Core.State fun st => { st with messages := savedMessages }
     return ← Tactic.saveState
 
 def communicate (obj : Json) : IO Unit :=
@@ -71,39 +85,51 @@ def isSolved (ss : Tactic.SavedState) : TacticM Bool := do
   return (← getUnsolvedGoals).isEmpty
 
 abbrev TacGen := List MVarId → MetaM (Array (String × Array PremiseSelectionResult × Float))
+/-- AlphaProof-style state value V(s): a negative estimate of the remaining
+proof length from the current tactic state. -/
 abbrev StateEval := List MVarId → MetaM Float
+
+structure SearchState where
+  state : Tactic.SavedState
+  score : Float
+  visitCount : Nat := 0
 
 inductive NodeData where
   | error (message : String)
-  | ok (state : Tactic.SavedState) (score : Float)
+  | ok (data : SearchState)
 
 namespace NodeData
 def priority : NodeData → TacticM Float
   | .error _ => return Float.inf
-  | .ok state score => do
-      if ← isSolved state then
+  | .ok data => do
+      if ← isSolved data.state then
         return Float.inf
       else
-        return score
+        return data.score
+
+def visitCount : NodeData → Nat
+  | .error _ => 0
+  | .ok data => data.visitCount
 
 def isTerminal : NodeData → TacticM Bool
   | .error _ => pure false
-  | .ok state _ => TreeSearch.isSolved state
+  | .ok data => TreeSearch.isSolved data.state
 
 def restore : NodeData → TacticM Unit
   | .error _ => pure ()
-  | .ok state _ => state.restore
+  | .ok data => data.state.restore
 
 end NodeData
 
 def ppNodeData : NodeData → TacticM Json
   | .error message => pure <| json%{ message: $message }
-  | .ok state score => do
-    state.restore
+  | .ok data => do
+    data.state.restore
     let pp ← (← getUnsolvedGoals).mapM fun g => do return toString (← Meta.ppGoal g)
     return json%{
       state: $(pp),
-      score: $(score)
+      score: $(data.score),
+      visitCount: $(data.visitCount)
     }
 
 def ppNode {ε} [ToJson ε] (node : Node NodeData ε) : TacticM Json := do
@@ -115,7 +141,9 @@ def ppNode {ε} [ToJson ε] (node : Node NodeData ε) : TacticM Json := do
 namespace BFS
 def expand (tg : TacGen) (se : Option StateEval) : NodeData → TacticM (Array (String × NodeData))
   | .error _ => pure #[]
-  | .ok state score => do
+  | .ok data => do
+    let state := data.state
+    let score := data.score
     state.restore
     let tactics ← tg (← getUnsolvedGoals)
     tactics.mapM fun (t, _, Δp) => do
@@ -130,7 +158,7 @@ def expand (tg : TacGen) (se : Option StateEval) : NodeData → TacticM (Array (
           se g
         else
           pure (score + Δp)
-        return (t, .ok s' p')
+        return (t, .ok ⟨s', p', 0⟩)
       else
         return (t, .error "")
 
@@ -143,7 +171,7 @@ def proofSearchBFS (tg : TacGen) (se : Option StateEval)
     (maxNodes := BestFirst.defaultMaxNodes) : TacticM Unit := do
   withCumulativeWallClockTime "reap.wall.bfs.total" do
     let (k, nodes) ← bestFirstSearch NodeData.priority NodeData.isTerminal
-      (expand tg se) (.ok (← Tactic.saveState) 0.0) maxNodes
+      (expand tg se) (.ok ⟨(← Tactic.saveState), 0.0, 0⟩) maxNodes
     let ppNodes ← nodes.mapM ppNode
     let info := json%{
       solution : $k,
@@ -152,8 +180,8 @@ def proofSearchBFS (tg : TacGen) (se : Option StateEval)
     communicate info
 
     if let some k := k then
-      let some {data := .ok state _, ..} := nodes[k]? | unreachable!
-      state.restore
+      let some {data := .ok data, ..} := nodes[k]? | unreachable!
+      data.state.restore
   printCumulativeWallClockTimes
 
 end BFS
@@ -164,79 +192,398 @@ structure EdgeData where
   tacticStr : String
   premise : Array PremiseSelectionResult
   prior : Float
-  visit : Nat := 0
+  totalValue : Float := 0.0   -- Sum of backed-up edge values V(s,a)
+  visitCount : Nat := 0       -- N(s,a): visit count
+  exhausted : Bool := false   -- subtree fully explored with no live options
 deriving ToJson
 
 abbrev NodeType := Node NodeData (EdgeData × NodeData)
 
+structure CheckedChild where
+  tacticStr : String
+  premise : Array PremiseSelectionResult
+  prior : Float
+  state : Tactic.SavedState
+  score : Float
+
+/-- Re-normalize policy mass after Lean has rejected invalid tactics.
+The tactic generator already softmaxes model log-probabilities over sampled
+candidates; after filtering to executable tactics, conditioning on validity is
+equivalent to dividing the remaining probability mass by its valid total. -/
+private def normalizeCheckedPriors (children : Array CheckedChild) : Array Float :=
+  if children.isEmpty then
+    #[]
+  else
+    let weights := children.map fun child =>
+      if child.prior > 0.0 then child.prior else 0.0
+    let total := weights.foldl (init := (0.0 : Float)) fun acc weight => acc + weight
+    if total <= (0.0 : Float) then
+      let uniform := 1.0 / children.size.toFloat
+      children.map fun _ => uniform
+    else
+      weights.map fun weight => weight / total
+
 def expand (tg : TacGen) (se : StateEval) (node : NodeType) : TacticM (Array (EdgeData × NodeData)) := do
-  if let .ok s₀ _ := node.data then
-    let mut ret := #[]
+  if let .ok data := node.data then
+    let mut checked := #[]
+    let s₀ := data.state
     s₀.restore
     let tactics ← tg (← getUnsolvedGoals)
     for (t, ps, p) in tactics do
       s₀.restore
       if let some s' ← evalTacticStr t (reap.heartbeats.get (← getOptions)) then
         s'.restore
-        -- TODO: figure out initialization of nodes
-        let score ← se (← getUnsolvedGoals)
-        ret := ret.push (⟨ t, ps, p, 1 ⟩, .ok s' score)
-      else
-        ret := ret.push (⟨ t, #[], 0, 0 ⟩, .error "")
+        let goals ← getUnsolvedGoals
+        let score ← if goals.isEmpty then pure 0.0 else se goals
+        checked := checked.push {
+          tacticStr := t
+          premise := ps
+          prior := p
+          state := s'
+          score := score
+        }
 
-    return ret
+    let priors := normalizeCheckedPriors checked
+    return checked.zipIdx.map fun childAndIdx =>
+      let child := childAndIdx.1
+      let i := childAndIdx.2
+      -- No virtual visit: edge starts unvisited so the first PUCT selection
+      -- reflects the prior, not a phantom Q value. The child node still
+      -- carries `score` so we can back it up on the first real rollout.
+      (⟨ child.tacticStr, child.premise, priors[i]!, 0.0, 0, false ⟩,
+        .ok ⟨child.state, child.score, 0⟩)
   else
     return #[]
 
-def c_base := 1.0
-def c_init := 0.0
-def visit_discount := 1.0
-def prior_temperature := 1.0
+def c_base := 19652.0
+def c_init := 2.5
+/-- Discount used by AlphaProof-style PUCT when mapping edge values V(s,a) to
+positive action values Q(s,a) = gamma^(-V(s,a)-1). -/
+def discountFactor := 0.99
+/-- Fixed penalty used to initialize an unvisited edge from the parent state's
+value estimate: V_init(s,a) = V(s) - fpuPenalty. -/
+def fpuPenalty := 32.0
+/-- Each tactic consumes one environment step with reward -1, so an edge value
+is one step worse than the resulting child state's value. -/
+def tacticStepCost := 1.0
+
+private def fmax (a b : Float) : Float := if a ≥ b then a else b
+
+private def qFromSearchValue (v : Float) : Float :=
+  if v == (0.0 - Float.inf) then
+    0.0 - Float.inf
+  else
+    let exponent := -v - tacticStepCost
+    Float.exp (Float.log discountFactor * exponent)
+
+/-- Whether an edge/child pair is a live candidate we may still pick.
+An edge is dead when either (a) the child is an `.error` (the tactic failed),
+or (b) we have already marked the edge as `exhausted` because its subtree has
+no live options left. -/
+private def isLive (e : EdgeData) (n : NodeData) : Bool :=
+  match n with
+  | .error _ => false
+  | .ok _ => !e.exhausted
 
 def computeScores (node : NodeType) : Array Float :=
-  let N := node.children.map (fun (e, _) => e.visit) |>.sum
-  -- exploration factor
-  let c := c_init + Float.log ((N.toFloat + c_base + 1) / c_base)
+  -- Continue to use the node visit count as N(s). This preserves prior-driven
+  -- first-choice behavior immediately after expansion, while edge statistics
+  -- store AlphaProof-style V(s,a) values.
+  let N := NodeData.visitCount node.data
+  -- Adaptive exploration coefficient (AlphaZero style)
+  let c := Float.log ((1.0 + N.toFloat + c_base) / c_base) + c_init
   node.children.map fun (e, n) =>
-    if let .ok _ score := n then
-      Float.exp (-visit_discount * (score + 1)) +
-        c * Float.pow e.prior prior_temperature * N.toFloat.sqrt / (e.visit.toFloat + 1)
+    if !isLive e n then
+      -- dead child: never select
+      0.0 - Float.inf
     else
-      -Float.inf
+      let parentValue := match node.data with
+        | .error _ => 0.0 - Float.inf
+        | .ok data => data.score
+      let v := if e.visitCount == 0 then
+        parentValue - fpuPenalty
+      else
+        e.totalValue / e.visitCount.toFloat
+      let q := qFromSearchValue v
+      let u := c * e.prior * N.toFloat.sqrt / (1.0 + e.visitCount.toFloat)
+      -- AlphaProof-style PUCT: transform V(s,a) into a positive Q(s,a).
+      q + u
 
+/-- Pick the child to descend into. Returns `none` if there is none to pick —
+either because the node has not been expanded yet (children empty) or because
+every child is dead/exhausted (dead-end). The framework distinguishes these
+two cases via `Node.expanded`. -/
 def selectChild (node : NodeType) : Option Nat :=
-  let scores := computeScores node
-  -- I could not find a convenient way in Std to compute argmax of an array
-  Id.run do
-    let mut bestIdx := none
-    let mut bestScore := -Float.inf
-    for (score, i) in scores.zipIdx do
-      if score > bestScore then
-        bestIdx := some i
-        bestScore := score
-    return bestIdx
+  if node.children.isEmpty then none
+  else
+    let scores := computeScores node
+    Id.run do
+      let mut bestIdx : Option Nat := none
+      let mut bestScore := -Float.inf
+      for (score, i) in scores.zipIdx do
+        -- Exclude strictly -inf candidates explicitly so "all dead" ⇒ none.
+        if score > -Float.inf && score > bestScore then
+          bestIdx := some i
+          bestScore := score
+      return bestIdx
 
-def updateEdge (e : EdgeData) : EdgeData :=
-  {
-    e with
-      visit := e.visit + 1
-  }
+def updateEdge (_parent : NodeData) (e : EdgeData) (child : NodeData) : EdgeData :=
+  match child with
+  | .ok data =>
+    -- A child that updated itself to `-∞` has declared its subtree exhausted.
+    -- Propagate that into the edge's `exhausted` bit so the parent's selector
+    -- treats it as dead. We still bump visitCount so we don't re-expand this
+    -- branch, but we do NOT fold `-∞` into `totalValue` (that would poison
+    -- the averaged V(s,a) estimate of a previously-live edge).
+    if data.score == (0.0 - Float.inf) then
+      { e with visitCount := e.visitCount + 1, exhausted := true }
+    else
+      let edgeValue := data.score - tacticStepCost
+      { e with
+        totalValue := e.totalValue + edgeValue
+        visitCount := e.visitCount + 1 }
+  | .error _ =>
+    -- `error` children are dead from birth (score = -∞ in the selector). This
+    -- branch is unreachable in practice because `selectChild` never picks an
+    -- error edge; handle it defensively.
+    { e with visitCount := e.visitCount + 1, exhausted := true }
+
+/-- Has this node been fully explored with no remaining live options? -/
+private def isExhausted (node : NodeType) : Bool :=
+  node.children.size > 0 &&
+    node.children.all (fun (e, n) => !isLive e n)
+
+private def findIncomingEdge?
+    (nodes : Array (Node NodeData (EdgeData × Nat))) (childIdx : Nat) :
+    Option (Nat × Nat) := Id.run do
+  for nodeAndIdx in nodes.zipIdx do
+    let parentIdx := nodeAndIdx.2
+    let node := nodeAndIdx.1
+    for edgeAndIdx in node.children.zipIdx do
+      if edgeAndIdx.1.2 == childIdx then
+        return some (parentIdx, edgeAndIdx.2)
+  return none
+
+private partial def solutionTacticsCore
+    (nodes : Array (Node NodeData (EdgeData × Nat))) (fuel : Nat) (nodeIdx : Nat)
+    (acc : List String) : Option (List String) :=
+  if nodeIdx == 0 then
+    some acc
+  else if fuel == 0 then
+    none
+  else
+    match findIncomingEdge? nodes nodeIdx with
+    | none => none
+    | some (parentIdx, edgeIdx) =>
+        match nodes[parentIdx]? with
+        | none => none
+        | some parent =>
+            match parent.children[edgeIdx]? with
+            | none => none
+            | some (edge, _) =>
+                solutionTacticsCore nodes (fuel - 1) parentIdx (edge.tacticStr :: acc)
+
+private def solutionTactics?
+    (nodes : Array (Node NodeData (EdgeData × Nat))) (nodeIdx : Nat) : Option (Array String) :=
+  (solutionTacticsCore nodes nodes.size nodeIdx []).map List.toArray
+
+private def markNodeError (nodeIdx : Nat) (message : String) :
+    StateT (Array (Node NodeData (EdgeData × Nat))) TacticM Unit := do
+  modify fun nodes =>
+    let nodes :=
+      match nodes[nodeIdx]? with
+      | none => nodes
+      | some node => nodes.set! nodeIdx { node with data := .error message }
+    match findIncomingEdge? nodes nodeIdx with
+    | none => nodes
+    | some (parentIdx, edgeIdx) =>
+        match nodes[parentIdx]? with
+        | none => nodes
+        | some parent =>
+            match parent.children[edgeIdx]? with
+            | none => nodes
+            | some (edge, childIdx) =>
+                let edge := { edge with exhausted := true }
+                nodes.set! parentIdx
+                  { parent with children := parent.children.set! edgeIdx (edge, childIdx) }
+
+private def exprContainsConst (declName : Name) (e : Expr) : Bool :=
+  e.foldConsts false fun constName found =>
+    found || constName == declName || (Lean.privateToUserName? constName).getD constName == declName
+
+private def rootProofContainsCurrentDecl (rootGoals : List MVarId) : TacticM Bool := do
+  let some declName ← Term.getDeclName? | return false
+  for goal in rootGoals do
+    let some proof ← getExprMVarAssignment? goal | return false
+    let proof ← instantiateMVars proof
+    if exprContainsConst declName proof then
+      return true
+  return false
+
+inductive FinalReplayResult where
+  | valid (state : Tactic.SavedState)
+  | invalid (message : String)
+
+private def validateFinalReplay
+    (rootState : Tactic.SavedState) (rootGoals : List MVarId) (tactics : Array String)
+    (heartbeats : Nat) : TacticM FinalReplayResult := do
+  let savedState ← Tactic.saveState
+  let savedMessages := (← getThe Core.State).messages
+  let result ← try
+    rootState.restore
+    modifyThe Core.State fun st => { st with messages := {} }
+    let mut failure : Option String := none
+    for tacticStr in tactics do
+      if failure.isNone then
+        if (← evalTacticStr tacticStr heartbeats).isNone then
+          failure := some s!"final replay rejected tactic: {tacticStr}"
+    if let some msg := failure then
+      pure (.invalid msg)
+    else
+      Term.synthesizeSyntheticMVarsNoPostponing
+      pruneSolvedGoals
+      if (← getThe Core.State).messages.hasErrors then
+        pure (.invalid "final replay produced Lean errors")
+      else if !(← getUnsolvedGoals).isEmpty then
+        pure (.invalid "final replay left unsolved goals")
+      else if ← rootProofContainsCurrentDecl rootGoals then
+        pure (.invalid "final proof self-references the declaration being proved")
+      else
+        pure (.valid (← Tactic.saveState))
+  catch _ =>
+    pure (.invalid "final replay threw an exception")
+  savedState.restore
+  modifyThe Core.State fun st => { st with messages := savedMessages }
+  return result
 
 def updateNode (node : NodeType) : NodeData :=
-  if let .ok state score := node.data then
-    .ok state (score + 1)
-  else
-    node.data
+  match node.data with
+  | .error msg => .error msg
+  | .ok data =>
+    let visitCount := data.visitCount + 1
+    if isExhausted node then
+      -- Mark the subtree as dead so the parent's `isLive` test excludes this
+      -- edge on subsequent selections. We encode "dead" as -∞ reward.
+      .ok { data with score := (0.0 - Float.inf), visitCount := visitCount }
+    else
+      -- Max backup on V(s,a): node value V(s) = max_a V(s,a).
+      let bestV := node.children.foldl (init := (0.0 - Float.inf)) fun acc (e, n) =>
+        if isLive e n && e.visitCount > 0 then
+          fmax acc (e.totalValue / e.visitCount.toFloat)
+        else
+          acc
+      .ok { data with
+        -- If no child edge has been visited yet, preserve the node's current
+        -- state-value estimate from expansion instead of overwriting it.
+        score := if bestV == (0.0 - Float.inf) then data.score else bestV,
+        visitCount := visitCount
+      }
+
+private partial def monteCarloTreeSearchVerified
+    (tg : TacGen) (se : StateEval)
+    (rootState : Tactic.SavedState) (rootGoals : List MVarId) (rootScore : Float)
+    (maxNodes := MCTS.defaultMaxNodes)
+    (maxSteps := MCTS.defaultMaxSteps) :
+    TacticM (Option (Nat × Tactic.SavedState) × Array (Node NodeData (EdgeData × Nat))) :=
+  StateT.run (s := #[ { data := NodeData.ok ⟨rootState, rootScore, 0⟩ } ]) do
+    let mut step := 0
+    while (← get).size < maxNodes && step < maxSteps do
+      let result ← _root_.TreeSearch.mctsStep
+        (fun x => x.isTerminal)
+        (expand tg se)
+        (fun x => return selectChild x)
+        (fun p e c => return updateEdge p e c)
+        (fun x => return updateNode x)
+        0
+      if let some k := result then
+        let nodes ← get
+        match solutionTactics? nodes k with
+        | none =>
+            markNodeError k "could not reconstruct final replay path"
+        | some tactics =>
+            match ← validateFinalReplay rootState rootGoals tactics (reap.heartbeats.get (← getOptions)) with
+            | .valid state => return some (k, state)
+            | .invalid msg => markNodeError k msg
+
+      let nodes ← get
+      if let some root := nodes[0]? then
+        if root.expanded then
+          let resolved ← _root_.TreeSearch.resolve root
+          if selectChild resolved |>.isNone then
+            return none
+      step := step + 1
+    return none
 
 structure PPNodeData where
   pp : List String
   value : Float
+  visitCount : Nat
 deriving ToJson
+
+structure PPEdgeData where
+  tacticStr : String
+  premise : Array PremiseSelectionResult
+  prior : Float
+  totalValue : Float
+  visitCount : Nat
+  exhausted : Bool
+  live : Bool
+  q : Option Float
+  u : Option Float
+  qPlusU : Option Float
+deriving ToJson, Inhabited
+
+private def computeEdgeBreakdown (parent : NodeData) (e : EdgeData) (child : NodeData) :
+    Bool × Option Float × Option Float × Option Float :=
+  let live := isLive e child
+  if !live then
+    (false, none, none, none)
+  else
+    let N := NodeData.visitCount parent
+    let c := Float.log ((1.0 + N.toFloat + c_base) / c_base) + c_init
+    let parentValue := match parent with
+      | .error _ => 0.0 - Float.inf
+      | .ok data => data.score
+    let v := if e.visitCount == 0 then
+      parentValue - fpuPenalty
+    else
+      e.totalValue / e.visitCount.toFloat
+    let q := qFromSearchValue v
+    let u := c * e.prior * N.toFloat.sqrt / (1.0 + e.visitCount.toFloat)
+    (true, some q, some u, some (q + u))
+
+private def ppEdgeData (parent : NodeData) (e : EdgeData) (child : NodeData) : PPEdgeData :=
+  let (live, q, u, qPlusU) := computeEdgeBreakdown parent e child
+  {
+    tacticStr := e.tacticStr
+    premise := e.premise
+    prior := e.prior
+    totalValue := e.totalValue
+    visitCount := e.visitCount
+    exhausted := e.exhausted
+    live := live
+    q := q
+    u := u
+    qPlusU := qPlusU
+  }
 
 def ppNodeData (node : NodeData) : TacticM PPNodeData := do
   node.restore
   let pp ← (← getUnsolvedGoals).mapM fun g => return toString (← Meta.ppGoal g)
-  return ⟨ pp, ← node.priority ⟩
+  return ⟨ pp, ← node.priority, NodeData.visitCount node ⟩
+
+def ppNode (nodes : Array (Node NodeData (EdgeData × Nat)))
+    (node : Node NodeData (EdgeData × Nat)) : TacticM Json := do
+  let children := node.children.map fun (e, childIdx) =>
+    match nodes[childIdx]? with
+    | some child => (ppEdgeData node.data e child.data, childIdx)
+    | none => unreachable!
+  let data := ← Reap.TreeSearch.ppNodeData node.data
+  return Json.mkObj [
+    ("data", toJson data),
+    ("children", toJson children),
+    ("expanded", toJson node.expanded)
+  ]
 
 end MCTS
 
@@ -245,24 +592,20 @@ def reapMCTS (tg : TacGen) (se : StateEval)
     (maxNodes := MCTS.defaultMaxNodes)
     (maxSteps := MCTS.defaultMaxSteps) : TacticM Unit := do
   withCumulativeWallClockTime "reap.wall.mcts.total" do
-    let (k, nodes) ← monteCarloTreeSearch
-      (fun x => x.isTerminal)
-      (expand tg se)
-      (fun x => return selectChild x)
-      (fun _ e _ => return updateEdge e)
-      (fun x => return updateNode x)
-      (NodeData.ok (← Tactic.saveState) 0.0)
-      maxNodes maxSteps
+    let rootState ← Tactic.saveState
+    let rootGoals ← getUnsolvedGoals
+    let rootScore ← if rootGoals.isEmpty then pure 0.0 else se rootGoals
+    let (result, nodes) ← monteCarloTreeSearchVerified tg se rootState rootGoals rootScore maxNodes maxSteps
+    let k := result.map Prod.fst
 
-    let ppNodes ← nodes.mapM ppNode
+    let ppNodes ← nodes.mapM (MCTS.ppNode nodes)
     let info := json%{
       solution : $k,
       nodes : $ppNodes
     }
     communicate info
 
-    if let some k := k then
-      let some {data := .ok state _, ..} := nodes[k]? | unreachable!
+    if let some (_, state) := result then
       state.restore
 
   printCumulativeWallClockTimes


### PR DESCRIPTION
Correct tactic evaluation by restoring Lean state/messages, synthesizing synthetic metavars, and pruning solved goals before accepting candidates.

Track node and edge visit/value statistics for AlphaProof-style PUCT, normalize valid-child priors, and mark exhausted branches dead during backup.

Validate discovered solutions by replaying tactic paths from the root before restoring final state, and enrich search-tree JSON with edge diagnostics for visualization.

Align policy/value prompting and scoring with the REAP service format by softmaxing policy priors, sharing premise-aware prompts, and using value scores directly.